### PR TITLE
Fixed min-height and flex-grow related bug on droppable areas.

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     />
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Kan-Do | Minimal Private Todo Manager</title>
+    <title>Kan-Do | Minimal, Private To-Do Manager</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/Task.jsx
+++ b/src/components/Task.jsx
@@ -26,7 +26,7 @@ function Task({ task, index }) {
           </div>
 
           {/* Task body */}
-          <div>{task.content}</div>
+          <p>{task.content}</p>
         </div>
       )}
     </Draggable>

--- a/src/features/boards/TaskColumn.jsx
+++ b/src/features/boards/TaskColumn.jsx
@@ -6,7 +6,7 @@ import { Droppable } from '@hello-pangea/dnd';
 
 function TaskColumn({ column, type, tasks }) {
   return (
-    <div className="flex h-[42rem] w-60 flex-shrink-0 flex-col gap-2 rounded-md bg-gray-200">
+    <div className="flex min-h-[42rem] w-60 flex-shrink-0 flex-col gap-2 rounded-md bg-gray-200">
       {/* Board title and dropdown button */}
       <div className="flex items-center justify-between p-3">
         <Badge text={column.title} type={type} />
@@ -28,7 +28,7 @@ function TaskColumn({ column, type, tasks }) {
           <div
             {...provided.droppableProps}
             ref={provided.innerRef}
-            className={`h-full gap-3 p-3 transition-colors duration-300 ${snapshot.isDraggingOver ? 'bg-blue-100' : ''}`}
+            className={`h-full flex-grow gap-3 p-3 transition-colors duration-300 ${snapshot.isDraggingOver ? 'bg-blue-100' : ''}`}
           >
             {/* For each task, we render a task component. */}
             {tasks.map((task, index) => (


### PR DESCRIPTION
Droppable areas' height were not adapting when the tasks required more space than the height defined on the column. Added a min-height to fix that and also added flex grow to the droppable divs so that, even with no elements, the droppable area would be equal to the space available in its parent container.